### PR TITLE
Update woocommerce dependency notice

### DIFF
--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -44,10 +44,10 @@ function wc_min_max_quantities_missing_wc_notice() {
 	$notice = '<div class="notice notice-error">';
 	$notice .= '<p>';
 	$notice .= sprintf(
-		__( '%1$s requires %2$s to be installed and active. You can download %3$s here.', 'wc-min-max-quantities' ),
+		__( '%1$s requires %2$s to be installed and active. You can download WooCommerce %3$s.', 'wc-min-max-quantities' ),
 		'<strong>WC Min Max Quantities</strong>',
 		'<strong>WooCommerce</strong>',
-		'<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">WooCommerce</a>'
+		'<a href="https://wordpress.org/plugins/woocommerce/" target="_blank">here</a>'
 	);
 	$notice .= '</p>';
 	$notice .= '</div>';


### PR DESCRIPTION
Update the woocommerce dependency notice to change the link and set the link in the proper position. 