### PR TITLE
Prepare release v2.0.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         run: |
           composer install
-          composer update --no-dev
+          composer install --no-dev
           npm install && npm run build
 
       - name: Release

--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2024 PluginEver
+# Copyright (C) 2025 PluginEver
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.0.6\n"
+"Project-Id-Version: WC Min Max Quantities 2.0.7\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2024-12-23 10:10:06+00:00\n"
+"POT-Creation-Date: 2025-02-09 08:10:41+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2025-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "GPL v2 or laterr",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/",
   "license": "GPL v2 or laterr",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max 
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 2.0.6
+Stable tag: 2.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,9 @@ The cart will maintain the global or product rules if the cart rule is not set.
 2. Global settings
 
 == Changelog ==
+= 2.0.7 (9th Feb 2025) =
+- Compatibility: Checked compatibility with the latest version of WordPress and WooCommerce.
+
 = 2.0.5 (3rd Dec 2024) =
 - Fix: Remove the unused code
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.0.6
+ * Version:              2.0.7
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver
@@ -14,7 +14,7 @@
  * License URI:          https://www.gnu.org/licenses/gpl-2.0.html
  * Tested up to:         6.7
  * WC requires at least: 3.0.0
- * WC tested up to:      9.5
+ * WC tested up to:      9.6
  * Requires Plugins:     woocommerce
  *
  * @package     WooCommerceMinMaxQuantities


### PR DESCRIPTION
This pull request includes several updates to the `WC Min Max Quantities` plugin, primarily focusing on version updates and ensuring compatibility with the latest versions of WordPress and WooCommerce.

Version and compatibility updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R26): Changed the `composer update --no-dev` command to `composer install --no-dev` in the build step.
* [`languages/wc-min-max-quantities.pot`](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L1-R11): Updated the project version to `2.0.7` and the POT creation date to `2025-02-09`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the plugin version to `2.0.7`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the stable tag to `2.0.7` and added a changelog entry for version `2.0.7` indicating compatibility checks with the latest WordPress and WooCommerce versions. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R179-R181)
* [`wc-min-max-quantities.php`](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6): Updated the plugin version to `2.0.7` and the WooCommerce tested up to version to `9.6`. [[1]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6) [[2]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL17-R17)