### PR TITLE
Prepare Release 2.0.8

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -27,7 +27,7 @@ class Notices {
 	 * @return void
 	 */
 	public function admin_notices() {
-		$installed_time = get_option( 'wc_min_max_quantities_installed' );
+		$installed_time = absint( get_option( 'wc_min_max_quantities_installed' ) );
 		$current_time   = wp_date( 'U' );
 
 		// Promotional notice for Black Friday.

--- a/includes/Admin/views/notices/upgrade.php
+++ b/includes/Admin/views/notices/upgrade.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 		<span class="dashicons dashicons-cart"></span>
 		<?php esc_attr_e( 'Upgrade now', 'wc-min-max-quantities' ); ?>
 	</a>
-	<a href="#" data-snooze="<?php echo esc_attr( WEEK_IN_SECONDS ); ?>">
+	<a href="#" data-snooze="<?php echo esc_attr( MONTH_IN_SECONDS ); ?>">
 		<span class="dashicons dashicons-clock"></span>
 		<?php esc_attr_e( 'Maybe later', 'wc-min-max-quantities' ); ?>
 	</a>

--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.0.7\n"
+"Project-Id-Version: WC Min Max Quantities 2.0.8\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-02-09 08:10:41+00:00\n"
+"POT-Creation-Date: 2025-03-04 05:43:43+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "GPL v2 or laterr",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/",
   "license": "GPL v2 or laterr",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max 
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 2.0.7
+Stable tag: 2.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,9 @@ The cart will maintain the global or product rules if the cart rule is not set.
 2. Global settings
 
 == Changelog ==
+= 2.0.8 (4th Mar 2025) =
+- Fix: Few known issues.
+
 = 2.0.7 (9th Feb 2025) =
 - Compatibility: Checked compatibility with the latest version of WordPress and WooCommerce.
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.0.7
+ * Version:              2.0.8
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver
@@ -14,7 +14,7 @@
  * License URI:          https://www.gnu.org/licenses/gpl-2.0.html
  * Tested up to:         6.7
  * WC requires at least: 3.0.0
- * WC tested up to:      9.6
+ * WC tested up to:      9.7
  * Requires Plugins:     woocommerce
  *
  * @package     WooCommerceMinMaxQuantities


### PR DESCRIPTION
This pull request includes several updates and fixes to the `wc-min-max-quantities` plugin, focusing on version updates, bug fixes, and minor improvements to the codebase. The most important changes include updating the version number across multiple files, fixing a bug in the `admin_notices` function, and adjusting the snooze duration for upgrade notices.

Version updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `2.0.7` to `2.0.8`.
* [`wc-min-max-quantities.php`](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6): Updated the version from `2.0.7` to `2.0.8`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the stable tag to `2.0.8` and added a changelog entry for version `2.0.8` with the date `4th Mar 2025`. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R179-R181)
* [`languages/wc-min-max-quantities.pot`](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L5-R7): Updated the `Project-Id-Version` and `POT-Creation-Date` to reflect version `2.0.8`.

Bug fixes:
* [`includes/Admin/Notices.php`](diffhunk://#diff-7b224f0a2d0911bce684e52679b4a8e67ecbfdc42a2892760a585547081b1ed3L30-R30): Fixed a bug in the `admin_notices` function by using `absint` to ensure the installed time is an absolute integer.

Minor improvements:
* [`includes/Admin/views/notices/upgrade.php`](diffhunk://#diff-764c907e8c5242f66ef8f991c53808bcaed7855fa5aaea29eb3ab8d8f84b2f58L38-R38): Changed the snooze duration for upgrade notices from `WEEK_IN_SECONDS` to `MONTH_IN_SECONDS`.

Prepare Release 2.0.8 and Fixed #197 