### PR TITLE
Prepare Release v2.0.9

### DIFF
--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.0.8\n"
+"Project-Id-Version: WC Min Max Quantities 2.0.9\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-03-04 05:43:43+00:00\n"
+"POT-Creation-Date: 2025-03-25 06:09:25+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "GPL v2 or laterr",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/",
   "license": "GPL v2 or laterr",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max 
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 2.0.8
+Stable tag: 2.0.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.0.8
+ * Version:              2.0.9
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request includes version updates for the `WC Min Max Quantities` plugin. The version has been incremented from 2.0.8 to 2.0.9 across several files to reflect the latest release.

Version updates:

* [`languages/wc-min-max-quantities.pot`](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L5-R7): Updated `Project-Id-Version` to 2.0.9 and `POT-Creation-Date` to the latest timestamp.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the `version` field to 2.0.9.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the `Stable tag` to 2.0.9.
* [`wc-min-max-quantities.php`](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6): Updated the `Version` field to 2.0.9.

And Prepare Release v2.0.9