### PR TITLE
Prepare Release v2.1.1

### DIFF
--- a/includes/Admin/Notices.php
+++ b/includes/Admin/Notices.php
@@ -31,7 +31,7 @@ class Notices {
 		$current_time   = absint( wp_date( 'U' ) );
 
 		// Show after 5 days.
-		if ( $installed_time && $current_time < ( $installed_time + ( 5 * DAY_IN_SECONDS ) ) ) {
+		if ( $installed_time && $current_time > ( $installed_time + ( 5 * DAY_IN_SECONDS ) ) ) {
 
 			if ( ! defined( 'WCMMQ_PRO_VERSION' ) ) {
 				// Upgrade notice.

--- a/includes/Admin/views/notices/upgrade.php
+++ b/includes/Admin/views/notices/upgrade.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 					// translators: %1$s: WC Min Max Quantities Pro link, %2$s: Coupon code.
 					__( 'Enjoy a <strong>10%% discount</strong> on %1$s! Use coupon code %2$s at checkout to grab the deal. Don’t miss out — this offer won’t last forever!', 'wc-min-max-quantities' ),
 					'<a href="https://pluginever.com/plugins/woocommerce-min-max-quantities-pro/?utm_source=plugin&utm_medium=notice&utm_campaign=flash-sale" target="_blank"><strong>WC Min Max Quantities Pro</strong></a>',
-					'<strong>PRO10</strong>'
+					'<strong>FLASH10</strong>'
 				)
 			);
 			?>

--- a/includes/Admin/views/notices/upgrade.php
+++ b/includes/Admin/views/notices/upgrade.php
@@ -21,9 +21,9 @@ defined( 'ABSPATH' ) || exit;
 			echo wp_kses_post(
 				sprintf(
 					// translators: %1$s: WC Min Max Quantities Pro link, %2$s: Coupon code.
-					__( 'Get access to %1$s with a <strong>20%% discount</strong> for the next <strong>72 hours</strong> only! Use coupon code %2$s at checkout. Hurry up, the offer ends soon.', 'wc-min-max-quantities' ),
+					__( 'Enjoy a <strong>10%% discount</strong> on %1$s! Use coupon code %2$s at checkout to grab the deal. Don’t miss out — this offer won’t last forever!', 'wc-min-max-quantities' ),
 					'<a href="https://pluginever.com/plugins/woocommerce-min-max-quantities-pro/?utm_source=plugin&utm_medium=notice&utm_campaign=flash-sale" target="_blank"><strong>WC Min Max Quantities Pro</strong></a>',
-					'<strong>FLASH20</strong>'
+					'<strong>PRO10</strong>'
 				)
 			);
 			?>

--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.1.0\n"
+"Project-Id-Version: WC Min Max Quantities 2.1.1\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-04-09 10:32:09+00:00\n"
+"POT-Creation-Date: 2025-04-16 09:34:01+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -255,9 +255,8 @@ msgstr ""
 #: includes/Admin/views/notices/upgrade.php:24
 #. translators: %1$s: WC Min Max Quantities Pro link, %2$s: Coupon code.
 msgid ""
-"Get access to %1$s with a <strong>20%% discount</strong> for the next "
-"<strong>72 hours</strong> only! Use coupon code %2$s at checkout. Hurry up, "
-"the offer ends soon."
+"Enjoy a <strong>10%% discount</strong> on %1$s! Use coupon code %2$s at "
+"checkout to grab the deal. Don’t miss out — this offer won’t last forever!"
 msgstr ""
 
 #: includes/Admin/views/notices/upgrade.php:36

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "GPL v2 or laterr",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/",
   "license": "GPL v2 or laterr",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: pluginever,manikmist09
 Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max to purchase, product limits to buy, products min, products max, set min and max, woocommerce min and max, quantity limits for products, quantity limits for product variations, quantity limits for products in cart, cost limits for products in cart, minimum product quantity, maximum product quantity, product quantity, product quantity category, quantity order, minimum, maximum, quantity, minimum purchase, maximum purchase, max quantity, cart maximum, max purchase, cart max, order limit, products purchase limit, limit products purchase, min max products purchase limit, min and max quantity for woocommerce
 Requires at least: 5.0
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,9 @@ The cart will maintain the global or product rules if the cart rule is not set.
 2. Global settings
 
 == Changelog ==
+= 2.1.1 (16th Apr 2025) =
+- Compatibility: Checked compatibility with the latest version of WordPress and WooCommerce.
+
 = 2.1.0 (9th Apr 2025) =
 - Fix: Remove the unused notices from the plugin.
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.1.0
+ * Version:              2.1.1
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver
@@ -12,9 +12,9 @@
  * Domain Path:          /languages
  * License:              GPL v2 or later
  * License URI:          https://www.gnu.org/licenses/gpl-2.0.html
- * Tested up to:         6.7
+ * Tested up to:         6.8
  * WC requires at least: 3.0.0
- * WC tested up to:      9.7
+ * WC tested up to:      9.8
  * Requires Plugins:     woocommerce
  *
  * @package     WooCommerceMinMaxQuantities


### PR DESCRIPTION
This pull request includes several updates and improvements to the `wc-min-max-quantities` plugin, including changes to the discount notice, version updates, and compatibility checks. Below is a summary of the most important changes:

### Discount Notice Update:
* Updated the discount notice message in `includes/Admin/views/notices/upgrade.php` to reflect a 10% discount instead of 20%, and changed the coupon code from `FLASH20` to `FLASH10`.

### Version and Compatibility Updates:
* Updated the plugin version to `2.1.1` in `package.json`, `readme.txt`, and `wc-min-max-quantities.php`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R7) [[3]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6)
* Checked and updated compatibility with the latest versions of WordPress and WooCommerce in `readme.txt` and `wc-min-max-quantities.php`. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R7) [[2]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL15-R17)

### Bug Fix:
* Fixed a logical error in the `admin_notices` function in `includes/Admin/Notices.php` to ensure the notice is shown after 5 days instead of before.

### Translation File Update:
* Updated the translation file `languages/wc-min-max-quantities.pot` to reflect the new discount message and updated version information. [[1]](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L5-R7) [[2]](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L258-R259)

These changes improve the plugin's functionality, update the discount offer, and ensure compatibility with the latest software versions.

Prepare Release v2.1.1