### PR TITLE
Prepare Release v2.1.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,9 @@ jobs:
           coverage: none
           tools: composer, cs2pr
 
+      - name: Setup github token
+        run: composer config -g github-oauth.github.com ${{ secrets.ACCESS_TOKEN }}
+
       - name: Install dependencies
         run: composer install
 
@@ -37,7 +40,7 @@ jobs:
           echo "{files}={$FILES}" >> $GITHUB_OUTPUT
 
       - name: Test changed files
-        run: ./vendor/bin/phpcs ${{ steps.changes.outputs.files }} --report-full --report-checkstyle=./.github/phpcs-report.xml --runtime-set testVersion 8.0
+        run: ./vendor/bin/phpcs ${{ steps.changes.outputs.files }} --ignore=*/vendor/*,*/vendor-prefixed/* --report-full --report-checkstyle=./.github/phpcs-report.xml --runtime-set testVersion 8.0
 
       - name: Upload PHPCS report
         if: ${{ always() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,9 @@
 name: Linting
 
 on:
-  pull_request:
+  push:
     branches:
       - master
-      - feature/*
-      - release/*
   workflow_dispatch:
     inputs:
       ref:

--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,4 @@ codeception.yml
 languages/*.
 
 # Build related files
-/bin/strauss.phar
 build

--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.1.1\n"
+"Project-Id-Version: WC Min Max Quantities 2.1.2\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-04-16 09:34:01+00:00\n"
+"POT-Creation-Date: 2025-05-04 05:11:44+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "GPL v2 or laterr",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/",
   "license": "GPL v2 or laterr",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max 
 Requires at least: 5.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,9 @@ The cart will maintain the global or product rules if the cart rule is not set.
 2. Global settings
 
 == Changelog ==
+= 2.1.2 (4th May 2025) =
+- Compatibility: Checked compatibility with the latest version of WordPress and WooCommerce.
+
 = 2.1.1 (16th Apr 2025) =
 - Compatibility: Checked compatibility with the latest version of WordPress and WooCommerce.
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.1.1
+ * Version:              2.1.2
  * Requires at least:    5.0
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request includes updates to the linting workflow and versioning for the `WC Min Max Quantities` plugin. The most significant changes involve modifying the GitHub Actions workflow for linting, updating the plugin version to `2.1.2`, and adding compatibility information for the latest WordPress and WooCommerce versions.

### Workflow Updates:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L4-L8): Changed the workflow trigger from `pull_request` to `push` and removed specific branch filters (`feature/*` and `release/*`).
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R28-R30): Added a step to configure the GitHub token using Composer.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L40-R41): Updated the `Test changed files` step to ignore specific directories (`*/vendor/*`, `*/vendor-prefixed/*`) during linting.

### Plugin Versioning:
* [`languages/wc-min-max-quantities.pot`](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L5-R7): Updated the project version to `2.1.2` and adjusted the POT creation date.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Bumped the plugin version from `2.1.1` to `2.1.2`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the stable tag to `2.1.2` and added a changelog entry for the new version, mentioning compatibility checks with the latest WordPress and WooCommerce versions. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R179-R181)
* [`wc-min-max-quantities.php`](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6): Updated the plugin version to `2.1.2` in the plugin header.
Prepare release v2.1.2