### PR TITLE
Prepare Release v2.1.7

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -44,7 +44,7 @@ function wcmmq_get_product_limits( $product_id, $variation_id = 0 ) {
 	if ( false === $limits ) {
 		$product = wc_get_product( $product_id );
 		// If the product lever overrides are enabled, use them otherwise use the global settings.
-		$override = ( $product instanceof WC_Product ) && get_post_meta( $product->get_id(), '_wcmmq_enable', true ) === 'yes';
+		$override = ( $product instanceof WC_Product ) && 'yes' === get_post_meta( $product->get_id(), '_wcmmq_enable', true );
 
 		if ( $override ) {
 			$limits = array(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -40,10 +40,12 @@ function wcmmq_is_product_excluded( $product_id, $variation_id = 0 ) {
  */
 function wcmmq_get_product_limits( $product_id, $variation_id = 0 ) {
 	$limits = wp_cache_get( "wcmmq-{$product_id}-{$variation_id}", 'wc-min-max-quantities' );
+
 	if ( false === $limits ) {
 		$product = wc_get_product( $product_id );
 		// If the product lever overrides are enabled, use them otherwise use the global settings.
-		$override = 'yes' === get_post_meta( $product->get_id(), '_wcmmq_enable', true );
+		$override = ( $product instanceof WC_Product ) && get_post_meta( $product->get_id(), '_wcmmq_enable', true ) === 'yes';
+
 		if ( $override ) {
 			$limits = array(
 				'step'    => (int) get_post_meta( $product->get_id(), '_wcmmq_step', true ),

--- a/languages/wc-min-max-quantities.pot
+++ b/languages/wc-min-max-quantities.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WC Min Max Quantities 2.1.6\n"
+"Project-Id-Version: WC Min Max Quantities 2.1.7\n"
 "Report-Msgid-Bugs-To: https://pluginever.com/support/\n"
-"POT-Creation-Date: 2025-07-15 10:33:10+00:00\n"
+"POT-Creation-Date: 2025-08-01 06:38:48+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "wc-min-max-quantities",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-min-max-quantities",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "GPL v2 or later",
       "devDependencies": {
         "@lodder/time-grunt": "^4.0.0",
-        "@wordpress/scripts": "^30.19.0",
+        "@wordpress/scripts": "^30.20.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "grunt": "^1.6.1",
@@ -342,19 +342,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1884,13 +1886,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2703,39 +2706,11 @@
       }
     },
     "node_modules/@keyv/serialize": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
-      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3"
-      }
-    },
-    "node_modules/@keyv/serialize/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -3726,9 +3701,9 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3866,9 +3841,9 @@
       "license": "MIT"
     },
     "node_modules/@sentry/core": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.38.0.tgz",
-      "integrity": "sha512-dUwSv1VXDfsrcY69a/cgZNDsFal6iYOf0C4T+/ylpmgYp5SVe3vQK+2FLXUMuvgnOf+kHO6IeW0RhnhSyUflmA==",
+      "version": "9.44.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.44.0.tgz",
+      "integrity": "sha512-U+KBNGgq/eXIj226CPtRk+n5dx0q1xGVvbLbyfAyeek9C/wxQ3f+mvqeVqF9cx8FfrWIOeDM1F8ISH5uRkjjQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3876,9 +3851,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.38.0.tgz",
-      "integrity": "sha512-OhfRTge6hncSehrTBHpnz5R66OWRd8WMKn6ZoS0nwBmTfREjPkNRfOADIUqEElfyuaNj+gWsqTM1/E915pnZew==",
+      "version": "9.44.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.44.0.tgz",
+      "integrity": "sha512-rU96Q7q7hL4s328z9zFS+ZRK6eHnLFjYbH8XHCxAxGFDLyg9kpkR5to9PjoI+QVPZ/LYAE+Xw0wStoMjWMCFsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3912,9 +3887,9 @@
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@prisma/instrumentation": "6.11.1",
-        "@sentry/core": "9.38.0",
-        "@sentry/node-core": "9.38.0",
-        "@sentry/opentelemetry": "9.38.0",
+        "@sentry/core": "9.44.0",
+        "@sentry/node-core": "9.44.0",
+        "@sentry/opentelemetry": "9.44.0",
         "import-in-the-middle": "^1.14.2",
         "minimatch": "^9.0.0"
       },
@@ -3923,14 +3898,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.38.0.tgz",
-      "integrity": "sha512-G0JmsntsvALoqS9iLTi4Jn1DcQB7gw9PY1Fmkdcdcf7i4EJEdRDX0tiD9ssDrcjgzzFPnm0PCrSAkIfTtd3Zyg==",
+      "version": "9.44.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.44.0.tgz",
+      "integrity": "sha512-M6HOcA73WWzRuhqw4Fd2dqv9zEsvMteSNYOguTexIQCT2pzk1srACrt4uFfLY01s9FIKjw+tjrQfTbni2adv7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.38.0",
-        "@sentry/opentelemetry": "9.38.0",
+        "@sentry/core": "9.44.0",
+        "@sentry/opentelemetry": "9.44.0",
         "import-in-the-middle": "^1.14.2"
       },
       "engines": {
@@ -3940,20 +3915,20 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
         "@opentelemetry/core": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/instrumentation": "^0.57.1 || ^0.202.0",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
         "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.38.0.tgz",
-      "integrity": "sha512-Oa0kk4EiBMwCvHS5ZI50M/SMNfGM9ztsmedFEfpS+mZz8y9C5Artd0ukGK4OAYcSBggNVQkhmmhWbwpNnRNQiw==",
+      "version": "9.44.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.44.0.tgz",
+      "integrity": "sha512-OeMiVoLqEXtpYE2VBAGmhK4GfbUa5ivDtL+AF4B+cR+NZkqZFlnA7ItquVfAa2Jd45TIyueEK8yjan5hluQYJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.38.0"
+        "@sentry/core": "9.44.0"
       },
       "engines": {
         "node": ">=18"
@@ -3962,7 +3937,6 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
         "@opentelemetry/core": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/instrumentation": "^0.57.1 || ^0.202.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       }
@@ -4366,13 +4340,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/body-parser": {
@@ -5280,9 +5254,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.26.0.tgz",
-      "integrity": "sha512-i4TOscjPkrzQPf5+M+1ls+GSYzZtF0/wU/8KYlEhkUGALlru4zUeWXY+XOXgpsOJKs07bMwBXGPmQMPoy/mfgw==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.27.0.tgz",
+      "integrity": "sha512-FzfXQL/DAlNrOeiz88p0ReV1TLofo0vWZfQOdd7OswwzfYsMlXue7ms7Qo23z8tag+nNYnqQp71atUD5vox+fg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5292,8 +5266,8 @@
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
         "@babel/runtime": "7.25.7",
-        "@wordpress/browserslist-config": "^6.26.0",
-        "@wordpress/warning": "^3.26.0",
+        "@wordpress/browserslist-config": "^6.27.0",
+        "@wordpress/warning": "^3.27.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -5486,9 +5460,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.2.0.tgz",
-      "integrity": "sha512-KwmKT3iHzZdjMikC/s4XF7/7dPdVa52vCWsC34F1LTzcM5livqhgfu2LUlXb+vb5Eh/Vj5rVrrdGLCxGwzJk8Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.3.0.tgz",
+      "integrity": "sha512-Xu7hDd95c96zOk/gAvANlSWFRl6YEduyjc2sN4pSwCM7zHIgwBELdLg9CyzgwuR7Y3XDNdBgptsS9OUHBiC22Q==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5497,9 +5471,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.26.0.tgz",
-      "integrity": "sha512-mPM9apzbkA7itrXUheh8hSlWXw6RIWs6ohWWbWYID8PeNo8PY24lnAoAD9zPij447dbkeIR7sjDpq2A7GbUGAA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.27.0.tgz",
+      "integrity": "sha512-lBl7ggE05IF3jp3USh2xaz/OnaO1dj4HaySGXXD56Z9ikRcmneyjiux3UmzeHYPPp00XXOcjZ7xGIMXQJOq2BQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5508,9 +5482,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.26.0.tgz",
-      "integrity": "sha512-toWtN5BeMZ8lukuDmf89hgt2s8mhwVaRPfG6BwbQfwGzCsKSFxOsktvqeCblKjAVYRbgAuvHWHxIxvQp7IEMMQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.27.0.tgz",
+      "integrity": "sha512-bCj39UT+jIJOm8lCQEXjz4SdADl1jVfccWs3nlZHbW5fxc+1Mh+lApnXKgmge9Ap+cuxvg9ewg+Hr3k8HC6dQg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5532,9 +5506,9 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.26.0.tgz",
-      "integrity": "sha512-iHlOONSqFoLq1Pb0cpCigwiJctxnkFtibFTKFAesKSJOYvhEzmDPP7ecrlOl9+/Tta8s0xVrLoAZ3tyZGsNTMQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.27.0.tgz",
+      "integrity": "sha512-UYjpPeI6vMZKWuZxegUoYu1zU+KumhUTm4EgRbo2TVxwkxeMrOX6XX7DP+NzaPj/DjkfVzfeRz9Ygby7lr6/LA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5554,17 +5528,17 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "22.12.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.12.0.tgz",
-      "integrity": "sha512-MBNMbVBMU/NBn3cSa+v/o3Avq6+A0nzVkiLGdvTfE1MG8C9/AQDopV4jA6RN0zAw/vxgEm5roGqU/0QZ8MhoAw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.13.0.tgz",
+      "integrity": "sha512-cD7NpkCwH3bPhNcS16P0SEvlXrlx5XN5yCT7CZo3DReRTFlOMKswIg/csqFgvypIW8L2Qla5Rzva1qVsWnQEvg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "7.25.7",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^8.26.0",
-        "@wordpress/prettier-config": "^4.26.0",
+        "@wordpress/babel-preset-default": "^8.27.0",
+        "@wordpress/prettier-config": "^4.27.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.2",
@@ -5644,9 +5618,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.26.0.tgz",
-      "integrity": "sha512-bpabACezbrAxaF/bDOsSpxwE+FWY04D6nbW5k8aNW6RaSRQOrzutosFFziKJXsUvadsOSA+TdenDwoomKYpx8A==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.27.0.tgz",
+      "integrity": "sha512-MTKc5oWkmzVqSP0SxH5XCxZEpFUgd+uBn2byEjtbSPqTi3n6uou+LybtRWHSKeCAHVBcq3Bsng1V14oJRyl7Pg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -5675,13 +5649,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.26.0.tgz",
-      "integrity": "sha512-8un/tyH4kklhG18NfZVTI98Dg9T0C/CYp5jFRnIN7wYy6IekXbfQSPwgdyaxIYB3p1RfLiRYsOTvsFr2NoiSww==",
+      "version": "12.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.27.0.tgz",
+      "integrity": "sha512-J2sYHUB5fdmJ9IVnb5AJkFUMusVAQCZdFvphYSZZ+wq9qvyEp8SrTcIT1uj5zE/S/HdpkTQKRaJ56x0RZI9lFQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.26.0",
+        "@wordpress/jest-console": "^8.27.0",
         "babel-jest": "29.7.0"
       },
       "engines": {
@@ -5694,9 +5668,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.26.0.tgz",
-      "integrity": "sha512-St9aHYxOoTUR+GqcCmnPFyl9EHBc88YsJM/5IbxlETAxFx3h6BJYeLqk0cBZtnew62Hr4Kexcye01NUB4+Rx+g==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.27.0.tgz",
+      "integrity": "sha512-BEumv8etwMVgz1xvO1TOuSbOVB4dBwhtM6dSHchd4m5RPfmt/FpX+NWToSbF06+l+Ha6PVry72TiQpdFok9c8w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5708,13 +5682,13 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.26.0.tgz",
-      "integrity": "sha512-Hm1WWwEAPEzZ5wVcXAEEcEWngSWGpVOr8C8KTTXwzlkbHl9FheceM1QdKFDO+qxT4ZNa6Lk+r5t/4WXeq7tYdw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.27.0.tgz",
+      "integrity": "sha512-iIhl8fc4zeN1rehf/bvC2+oIFSTiFfnZf2aTDCzErQTgvGZ33cUlfx7CrpJPcVYCQcbvp4IdaYgaVaw/lnpmuQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.2.0",
+        "@wordpress/base-styles": "^6.3.0",
         "autoprefixer": "^10.4.20"
       },
       "engines": {
@@ -5726,9 +5700,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.26.0.tgz",
-      "integrity": "sha512-tcPFZKRG6lpoYo3Dbpw/Zlkbp6ZUVUDrcq8C9wIjKzuNjRssKxr2jBmCfoERMzNRE+3d0nlpqo+3iBFnlraKSA==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.27.0.tgz",
+      "integrity": "sha512-G9sNZ13tgoCwYxZ49jvWMROcRw4JuQjlcct275CAz5wc+blTyob8YPlWAyAJY1h1Q0Nr8cuclS+kdzwD8HCUkg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -5740,25 +5714,25 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "30.19.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.19.0.tgz",
-      "integrity": "sha512-vjsuBNdj81CAyL4XF6DLzIxF3gQGc7vtnJeOaksOy0M0lOrBdHr+THd0UhNgAG2SiBIN/jJYdrGeo/9omHZT1w==",
+      "version": "30.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.20.0.tgz",
+      "integrity": "sha512-LV3WG1UR7QeE4zE6nkWi6r3bmPn+MyjWOA0Ycpy23kOoabeurSob/hurfPUjzg4/i4wipJZ9MQyV4uWSEGHt4w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.26.0",
-        "@wordpress/browserslist-config": "^6.26.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.26.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.26.0",
-        "@wordpress/eslint-plugin": "^22.12.0",
-        "@wordpress/jest-preset-default": "^12.26.0",
-        "@wordpress/npm-package-json-lint-config": "^5.26.0",
-        "@wordpress/postcss-plugins-preset": "^5.26.0",
-        "@wordpress/prettier-config": "^4.26.0",
-        "@wordpress/stylelint-config": "^23.18.0",
+        "@wordpress/babel-preset-default": "^8.27.0",
+        "@wordpress/browserslist-config": "^6.27.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.27.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.27.0",
+        "@wordpress/eslint-plugin": "^22.13.0",
+        "@wordpress/jest-preset-default": "^12.27.0",
+        "@wordpress/npm-package-json-lint-config": "^5.27.0",
+        "@wordpress/postcss-plugins-preset": "^5.27.0",
+        "@wordpress/prettier-config": "^4.27.0",
+        "@wordpress/stylelint-config": "^23.19.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -5936,9 +5910,9 @@
       }
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.18.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.18.0.tgz",
-      "integrity": "sha512-/35cWr3cky5fJNs5kqI+/c05YMnAVZM3cdJfmt4e2oobI2YLUDrN0hojF3zVZJgNIzryJG1v7F2S6UIUrjErkg==",
+      "version": "23.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.19.0.tgz",
+      "integrity": "sha512-qriyn7AVc+h18yCh7oK/XY776THnENL7kuZi9IEM08k2dVmBt4hOeJlEKqumkBCBqtA/+JFPT38GlJpaV1+cHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5956,9 +5930,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.26.0.tgz",
-      "integrity": "sha512-7vVvrG29eMaH7lxr5ZYDPUMalACZoBqblK8UzZBunXROXmiBfhhZPylfj9DK4wxrfyvhsLWnvewHWxim/pZ3Zg==",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.27.0.tgz",
+      "integrity": "sha512-AGcCLU2urtV7C4i4Oji8tL9froFPDie+99A2N3tqjZU1v7Csw4UgDrptYRyENjhXLBe9ZzVlf1mZmgH/MQPAHA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -6795,9 +6769,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6818,7 +6792,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -7181,24 +7155,24 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.1.tgz",
-      "integrity": "sha512-Fa2BZY0CS9F0PFc/6aVA6tgpOdw+hmv9dkZOlHXII5v5Hw+meJBIWDcPrG9q/dXxGcNbym5t77fzmawrBQfTmQ==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
+      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.10.0",
-        "keyv": "^5.3.4"
+        "keyv": "^5.4.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.4.tgz",
-      "integrity": "sha512-ypEvQvInNpUe+u+w8BIcPkQvEqXquyyibWE/1NB5T2BTzIpS5cGEV1LZskDzPSTvNAaT4+5FutvzlvnkxOSKlw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.4.0.tgz",
+      "integrity": "sha512-TMckyVjEoacG5IteUpUrOBsFORtheqziVyyY2dLUwg1jwTb8u48LX4TgmtogkNl9Y9unaEJ1luj10fGyjMGFOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@keyv/serialize": "^1.0.3"
+        "@keyv/serialize": "^1.1.0"
       }
     },
     "node_modules/call-bind": {
@@ -9289,9 +9263,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
+      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9697,9 +9671,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
-      "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
+      "integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11746,9 +11720,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.10.0.tgz",
-      "integrity": "sha512-dJw0492Iddsj56U1JsSTm9E/0B/29a1AuoSLRAte8vQg/kaTGF3IgjEWT8c8yG4cC10+HisE1x5QAwR0Xwc+DA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
+      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14068,32 +14042,15 @@
       }
     },
     "node_modules/lighthouse-logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.1.tgz",
-      "integrity": "sha512-ioBrW3s2i97noEmnXxmUq7cjIcVRjT5HBpAYy8zE11CxU9HqlWHHeRxfeN1tn8F7OEMVPIC9x1f8t3Z7US9ehQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^2.6.9",
+        "debug": "^4.4.1",
         "marky": "^1.2.2"
       }
-    },
-    "node_modules/lighthouse-logger/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/lighthouse-logger/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lighthouse-stack-packs": {
       "version": "1.12.2",
@@ -14103,9 +14060,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
-      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14114,7 +14071,7 @@
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
         "semver": "^7.7.2",
-        "tar-fs": "^3.0.8",
+        "tar-fs": "^3.1.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -14138,14 +14095,14 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
-      "version": "24.12.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.12.1.tgz",
-      "integrity": "sha512-8odp6d3ERKBa3BAVaYWXn95UxQv3sxvP1reD+xZamaX6ed8nCykhwlOiHSaHR9t/MtmIB+rJmNencI6Zy4Gxvg==",
+      "version": "24.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.15.0.tgz",
+      "integrity": "sha512-2iy0iBeWbNyhgiCGd/wvGrDSo73emNFjSxYOcyAqYiagkYt5q4cPfVXaVDKBsukgc2fIIfLAalBZlaxldxdDYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
+        "@puppeteer/browsers": "2.10.6",
+        "chromium-bidi": "7.2.0",
         "debug": "^4.4.1",
         "devtools-protocol": "0.0.1464554",
         "typed-query-selector": "^2.12.0",
@@ -14156,9 +14113,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
-      "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.2.0.tgz",
+      "integrity": "sha512-gREyhyBstermK+0RbcJLbFhcQctg92AGgDe/h/taMJEOLRdtSswBAO9KmvltFSQWgM2LrwWu5SIuEUbdm3JsyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19301,9 +19258,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.21.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.21.1.tgz",
-      "integrity": "sha512-WCXdXnYK2tpCbebgMF0Bme3YZH/Rh/UXerj75twYo4uLULlcrLwFVdZTvTEF8idFnAcW21YUDJFyKOfaf6xJRw==",
+      "version": "16.23.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.0.tgz",
+      "integrity": "sha512-69T5aS2LUY306ekt1Q1oaSPwz/jaG9HjyMix3UMrai1iEbuOafBe2Dh8xlyczrxFAy89qcKyZWWtc42XLx3Bbw==",
       "dev": true,
       "funding": [
         {
@@ -19330,7 +19287,7 @@
         "debug": "^4.4.1",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.1",
+        "file-entry-cache": "^10.1.3",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -19472,9 +19429,9 @@
       "license": "MIT"
     },
     "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.22.1.tgz",
-      "integrity": "sha512-u9Xnc9zLuF/CL2IHPow7HcXPpb8okQyzYpwL5wFsY//JRedSWYglYRg3PYWoQCu1zO+tBTmWOJN/iM0mPC5CRQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.23.0.tgz",
+      "integrity": "sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -19595,23 +19552,23 @@
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.1.tgz",
-      "integrity": "sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
+      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.10"
+        "flat-cache": "^6.1.12"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.11",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.11.tgz",
-      "integrity": "sha512-zfOAns94mp7bHG/vCn9Ru2eDCmIxVQ5dELUHKjHfDEOJmHNzE+uGa6208kfkgmtym4a0FFjEuFksCXFacbVhSg==",
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
+      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.1",
+        "cacheable": "^1.10.3",
         "flatted": "^3.3.3",
         "hookified": "^1.10.0"
       }
@@ -19842,13 +19799,13 @@
       "dev": true
     },
     "node_modules/synckit": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
-      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.4"
+        "@pkgr/core": "^0.2.9"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -19908,9 +19865,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wc-min-max-quantities",
   "title": "Min Max Quantities for WooCommerce",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.",
   "homepage": "https://pluginever.com/plugins/woocommerce-min-max-quantities-pro/",
   "license": "GPL v2 or later",
@@ -21,7 +21,7 @@
     "test:unit": "wp-scripts test-unit-js"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^30.19.0",
+    "@wordpress/scripts": "^30.20.0",
     "@lodder/time-grunt": "^4.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/readme.txt
+++ b/readme.txt
@@ -177,7 +177,7 @@ The cart will maintain the global or product rules if the cart rule is not set.
 
 == Changelog ==
 = 2.1.7 (1st Aug 2025) =
-- Fix: Fixed few known issues.
+- Fix: Fixed known bug.
 
 = 2.1.6 (15th July 2025) =
 - Compatibility: Checked compatibility with the WooCommerce v10.0.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: limit quantity, limit cost, woocommerce limits, range to buy, min and max 
 Requires at least: 5.2
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 2.1.6
+Stable tag: 2.1.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -176,6 +176,9 @@ The cart will maintain the global or product rules if the cart rule is not set.
 2. Global settings
 
 == Changelog ==
+= 2.1.7 (1st Aug 2025) =
+- Fix: Fixed few known issues.
+
 = 2.1.6 (15th July 2025) =
 - Compatibility: Checked compatibility with the WooCommerce v10.0.
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WC Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.1.6
+ * Version:              2.1.7
  * Requires at least:    5.2
  * Requires PHP:         7.4
  * Author:               PluginEver


### PR DESCRIPTION
This pull request updates the plugin `WC Min Max Quantities` to version 2.1.7, addressing a bug fix and making minor updates to metadata and dependencies. Below are the key changes grouped by theme:

### Bug Fix:
* Fixed a potential issue in `wcmmq_get_product_limits` by adding a check to ensure `$product` is an instance of `WC_Product` before accessing its methods. (`includes/functions.php`, [includes/functions.phpR43-R48](diffhunk://#diff-1c08b27bcf43583c75cbc442bc401638be3427586fe544f3389e22c9979fa1afR43-R48))

### Version and Metadata Updates:
* Updated the plugin version from `2.1.6` to `2.1.7` across multiple files, including `package.json`, `readme.txt`, `wc-min-max-quantities.php`, and `wc-min-max-quantities.pot`. (`package.json`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4); `readme.txt`, [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7); `wc-min-max-quantities.php`, [[3]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6); `languages/wc-min-max-quantities.pot`, [[4]](diffhunk://#diff-b74d0854deacb063d4faabd96cefa539bc10f2e8530174b0b155e9c6b2f75821L5-R7)
* Added a changelog entry for version `2.1.7` in `readme.txt`, noting the bug fix. (`readme.txt`, [readme.txtR179-R181](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R179-R181))

### Dependency Update:
* Updated `@wordpress/scripts` dependency from `^30.19.0` to `^30.20.0` in `package.json`. (`package.json`, [package.jsonL24-R24](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R24))