### PR TITLE
Release/2.2.9

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -30,6 +30,12 @@ final class Plugin extends B8\Plugin\App {
 		define( 'WCMMQ_ASSETS_PATH', $this->assets_path() );
 		define( 'WCMMQ_ASSETS_URL', $this->assets_url() );
 
+		// Keep our caches request-scoped. The cached product limits pass through
+		// filters whose output can depend on the current user (e.g. role-based
+		// overrides from the Pro add-on), so persisting them across requests in
+		// Redis/Memcached/etc. would leak one user's limits to another.
+		wp_cache_add_non_persistent_groups( array( 'wc-min-max-quantities' ) );
+
 		register_activation_hook( $this->file, array( Installer::class, 'install' ) );
 		add_filter( 'plugin_action_links_' . $this->basename(), array( $this, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pluginever,manikmist09
 Tags: limit cost, limit quantity, min and max to purchase, cart limits, woocommerce limits
 Tested up to: 6.9
-Stable tag: 2.2.8
+Stable tag: 2.2.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -215,6 +215,13 @@ For support, visit our [support page](https://pluginever.com/support/) or use th
 12. Product > Categories (Pro)
 
 == Changelog ==
+= 2.2.9 (20th Apr 2026) =
+* Fix: Stale product min/max quantity values when a persistent object cache (e.g., Redis, Memcached) is active. Product limit caches are now declared non-persistent so updates take effect immediately without a manual cache flush.
+* Compatibility: Checked compatibility with WooCommerce v10.7.
+
+= 2.2.8 (31st Mar 2026) =
+* Enhance: Updated development dependencies for improved build-chain security.
+
 = 2.2.7 (12th Mar 2026) =
 * Fix: Addressed a minor issue related to the plugin's compatibility with the framework update in version 2.2.6.
 

--- a/wc-min-max-quantities.php
+++ b/wc-min-max-quantities.php
@@ -3,7 +3,7 @@
  * Plugin Name:          Min Max Quantities
  * Plugin URI:           https://pluginever.com/woocommerce-min-max-quantities-pro/
  * Description:          The plugin allows you to Set minimum and maximum allowable product quantities and price per product and order.
- * Version:              2.2.8
+ * Version:              2.2.9
  * Requires at least:    5.2
  * Tested up to:         6.9
  * Requires PHP:         7.4
@@ -14,7 +14,7 @@
  * Text Domain:          wc-min-max-quantities
  * Domain Path:          /languages
  * WC requires at least: 3.0.0
- * WC tested up to:      10.6
+ * WC tested up to:      10.7
  * Requires Plugins:     woocommerce
  *
  * @link                 https://pluginever.com
@@ -48,7 +48,7 @@ require_once __DIR__ . '/includes/functions.php';
 WooCommerceMinMaxQuantities\Plugin::create(
 	__FILE__,
 	array(
-		'version'       => '2.2.8',
+		'version'       => '2.2.9',
 		'option_prefix' => 'wcmmq',
 		'hook_prefix'   => 'wc_min_max_quantities',
 		'settings_url'  => admin_url( 'admin.php?page=wc-min-max-quantities' ),


### PR DESCRIPTION
This pull request addresses a caching issue affecting product min/max quantity limits when a persistent object cache (such as Redis or Memcached) is active. It ensures that cached product limits are now request-scoped to prevent stale or incorrect values from being served to users, and updates compatibility and version information.

Caching and compatibility improvements:

* Ensured that the `wc-min-max-quantities` cache group is declared non-persistent in `Plugin.php` to prevent leaking product limit values between users when persistent object caching is enabled.
* Updated WooCommerce compatibility to version 10.7 and marked the plugin as tested up to WordPress 6.9 [[1]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL17-R17) [[2]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6).
* Bumped the plugin version to 2.2.9 in all relevant files (`wc-min-max-quantities.php`, `readme.txt`) [[1]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL6-R6) [[2]](diffhunk://#diff-9876c44ec803e69f2fce23d8c88a81bf2cd504d26b4836ca636756f01170384eL51-R51) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R5).
* Added a changelog entry describing the cache fix and compatibility check for WooCommerce 10.7.