### PR TITLE
Add opt-in decimal quantity support

### DIFF
--- a/includes/Admin/MetaBoxes.php
+++ b/includes/Admin/MetaBoxes.php
@@ -82,12 +82,15 @@ class MetaBoxes {
 
 			woocommerce_wp_text_input(
 				array(
-					'id'          => '_wcmmq_step',
-					'label'       => __( 'Quantity step', 'wc-min-max-quantities' ),
-					'description' => __( 'Enter a number that will increment or decrement every time a quantity is changed for this product.', 'wc-min-max-quantities' ),
-					'desc_tip'    => true,
-					'type'        => 'number',
-					'min'         => '0',
+					'id'                => '_wcmmq_step',
+					'label'             => __( 'Quantity step', 'wc-min-max-quantities' ),
+					'description'       => __( 'Enter a number that will increment or decrement every time a quantity is changed for this product.', 'wc-min-max-quantities' ),
+					'desc_tip'          => true,
+					'type'              => 'number',
+					'custom_attributes' => array(
+						'step' => 'any',
+						'min'  => '0',
+					),
 				)
 			);
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -47,27 +47,47 @@ class Settings extends \WooCommerceMinMaxQuantities\ByteKit\Admin\Settings {
 					),
 					// set the minimum quantity.
 					array(
-						'title'   => __( 'Minimum quantity', 'wc-min-max-quantities' ),
-						'desc'    => __( 'Set minimum quantity for each product. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
-						'id'      => 'wcmmq_min_qty',
-						'default' => 0,
-						'type'    => 'number',
+						'title'             => __( 'Minimum quantity', 'wc-min-max-quantities' ),
+						'desc'              => __( 'Set minimum quantity for each product. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
+						'id'                => 'wcmmq_min_qty',
+						'default'           => 0,
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'step' => 'any',
+							'min'  => '0',
+						),
 					),
 					// set the maximum quantity.
 					array(
-						'title'   => __( 'Maximum quantity', 'wc-min-max-quantities' ),
-						'desc'    => __( 'Set maximum quantity for each product. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
-						'id'      => 'wcmmq_max_qty',
-						'default' => 0,
-						'type'    => 'number',
+						'title'             => __( 'Maximum quantity', 'wc-min-max-quantities' ),
+						'desc'              => __( 'Set maximum quantity for each product. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
+						'id'                => 'wcmmq_max_qty',
+						'default'           => 0,
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'step' => 'any',
+							'min'  => '0',
+						),
 					),
 					// Quantity step.
 					array(
-						'title'   => __( 'Quantity step', 'wc-min-max-quantities' ),
-						'desc'    => __( 'Each time the quantity is changed, it will be increased or decreased by this value. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
-						'id'      => 'wcmmq_step',
-						'default' => 0,
-						'type'    => 'number',
+						'title'             => __( 'Quantity step', 'wc-min-max-quantities' ),
+						'desc'              => __( 'Each time the quantity is changed, it will be increased or decreased by this value. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
+						'id'                => 'wcmmq_step',
+						'default'           => 0,
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'step' => 'any',
+							'min'  => '0',
+						),
+					),
+					// Allow decimal quantities.
+					array(
+						'title'   => __( 'Allow decimal quantities', 'wc-min-max-quantities' ),
+						'desc'    => __( 'Allow products and cart items to use fractional quantities (e.g., 0.5, 1.25). Some third-party integrations, reports, and stock sync tools may assume whole numbers — test on staging before enabling in production.', 'wc-min-max-quantities' ),
+						'id'      => 'wcmmq_decimal_quantities',
+						'default' => 'no',
+						'type'    => 'checkbox',
 					),
 					// end product restrictions section.
 					array(
@@ -81,20 +101,28 @@ class Settings extends \WooCommerceMinMaxQuantities\ByteKit\Admin\Settings {
 						'desc'  => __( 'Set the minimum and maximum limits for the order. Restrictions will be applied to the order total.', 'wc-min-max-quantities' ),
 					),
 					array(
-						'title'    => esc_html__( 'Minimum quantity', 'wc-min-max-quantities' ),
-						'desc'     => __( 'Set minimum quantity for the order. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
-						'desc_tip' => __( 'This will be calculated by adding the quantity of all products in the cart.', 'wc-min-max-quantities' ),
-						'id'       => 'wcmmq_min_cart_qty',
-						'default'  => 0,
-						'type'     => 'number',
+						'title'             => esc_html__( 'Minimum quantity', 'wc-min-max-quantities' ),
+						'desc'              => __( 'Set minimum quantity for the order. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
+						'desc_tip'          => __( 'This will be calculated by adding the quantity of all products in the cart.', 'wc-min-max-quantities' ),
+						'id'                => 'wcmmq_min_cart_qty',
+						'default'           => 0,
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'step' => 'any',
+							'min'  => '0',
+						),
 					),
 					array(
-						'title'    => esc_html__( 'Maximum quantity', 'wc-min-max-quantities' ),
-						'desc'     => __( 'Set maximum quantity for the order. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
-						'desc_tip' => __( 'This will be calculated by adding the quantity of all products in the cart.', 'wc-min-max-quantities' ),
-						'id'       => 'wcmmq_max_cart_qty',
-						'default'  => 0,
-						'type'     => 'number',
+						'title'             => esc_html__( 'Maximum quantity', 'wc-min-max-quantities' ),
+						'desc'              => __( 'Set maximum quantity for the order. Keep it blank if you don’t want to set any rule for this.', 'wc-min-max-quantities' ),
+						'desc_tip'          => __( 'This will be calculated by adding the quantity of all products in the cart.', 'wc-min-max-quantities' ),
+						'id'                => 'wcmmq_max_cart_qty',
+						'default'           => 0,
+						'type'              => 'number',
+						'custom_attributes' => array(
+							'step' => 'any',
+							'min'  => '0',
+						),
 					),
 					array(
 						'title'             => esc_html__( 'Minimum total', 'wc-min-max-quantities' ),

--- a/includes/Cart.php
+++ b/includes/Cart.php
@@ -199,7 +199,7 @@ class Cart {
 		$limits = wcmmq_get_product_limits( $product_id, $variation_id );
 		if ( $limits['min_qty'] > 0 ) {
 
-			if ( $product->managing_stock() && ! $product->backorders_allowed() && absint( $limits['min_qty'] ) > $product->get_stock_quantity() ) {
+			if ( $product->managing_stock() && ! $product->backorders_allowed() && $limits['min_qty'] > $product->get_stock_quantity() ) {
 				$data['min_value'] = $product->get_stock_quantity();
 
 			} else {
@@ -212,7 +212,7 @@ class Cart {
 			if ( $product->managing_stock() && $product->backorders_allowed() ) {
 				$data['max_value'] = $limits['max_qty'];
 
-			} elseif ( $product->managing_stock() && absint( $limits['max_qty'] ) > $product->get_stock_quantity() ) {
+			} elseif ( $product->managing_stock() && $limits['max_qty'] > $product->get_stock_quantity() ) {
 				$data['max_value'] = $product->get_stock_quantity();
 
 			} else {
@@ -221,9 +221,9 @@ class Cart {
 		}
 
 		if ( $limits['step'] > 0 ) {
-			$data['step'] = 1;
-			// If both minimum and maximum quantity are set, make sure both are equally divisible by group of quantity.
-			if ( ( empty( $limits['max_qty'] ) || absint( $limits['max_qty'] ) % absint( $limits['step'] ) === 0 ) && ( empty( $limits['min_qty'] ) || absint( $limits['min_qty'] ) % absint( $limits['step'] ) === 0 ) ) {
+			$data['step'] = wcmmq_is_integer_qty() ? 1 : 'any';
+			// Only expose the configured step when both limits are divisible by it, otherwise fall back to a permissive step.
+			if ( ( empty( $limits['max_qty'] ) || wcmmq_is_valid_step( $limits['max_qty'], $limits['step'] ) ) && ( empty( $limits['min_qty'] ) || wcmmq_is_valid_step( $limits['min_qty'], $limits['step'] ) ) ) {
 				$data['step'] = $limits['step'];
 			}
 		}
@@ -270,23 +270,23 @@ class Cart {
 		}
 
 		if ( $product_limits['max_qty'] > 0 && ( $total_quantity > $product_limits['max_qty'] ) ) {
-			/* translators: %1$s: Product name, %2$d: Maximum quantity */
-			$message = sprintf( __( 'The maximum allowed quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_formatted_name() ), number_format( $product_limits['max_qty'] ) );
+			/* translators: %1$s: Product name, %2$s: Maximum quantity */
+			$message = sprintf( __( 'The maximum allowed quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_formatted_name() ), wcmmq_format_qty( $product_limits['max_qty'] ) );
 			wcmmq_add_cart_notice( $message );
 
 			return false;
 		}
 
 		if ( ! wcmmq_is_allow_combination( $product_id ) && $product_limits['min_qty'] > 0 && $total_quantity < $product_limits['min_qty'] ) {
-			/* translators: %1$s: Product name, %2$d: Minimum quantity */
-			wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), $product->get_formatted_name(), number_format( $product_limits['min_qty'] ) ) );
+			/* translators: %1$s: Product name, %2$s: Minimum quantity */
+			wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), $product->get_formatted_name(), wcmmq_format_qty( $product_limits['min_qty'] ) ) );
 
 			return false;
 		}
 
-		if ( ! wcmmq_is_allow_combination( $product_id ) && $product_limits['step'] > 0 && ( (int) $quantity % (int) $product_limits['step'] > 0 ) ) {
-			/* translators: %1$s: Product name, %2$d: Group amount */
-			wcmmq_add_cart_notice( sprintf( __( 'The quantity of %1$s must be purchased in groups of %2$s.', 'wc-min-max-quantities' ), $product->get_formatted_name(), $product_limits['step'], $product_limits['step'] - ( $quantity % $product_limits['step'] ) ) );
+		if ( ! wcmmq_is_allow_combination( $product_id ) && ! wcmmq_is_valid_step( $quantity, $product_limits['step'] ) ) {
+			/* translators: %1$s: Product name, %2$s: Group amount */
+			wcmmq_add_cart_notice( sprintf( __( 'The quantity of %1$s must be purchased in groups of %2$s.', 'wc-min-max-quantities' ), $product->get_formatted_name(), wcmmq_format_qty( $product_limits['step'] ) ) );
 
 			return false;
 		}
@@ -295,8 +295,8 @@ class Cart {
 		$cart_limits = wcmmq_get_cart_limits();
 
 		if ( $cart_limits['max_qty'] > 1 && WC()->cart->cart_contents_count > $cart_limits['max_qty'] ) {
-			/* translators: %d: Maximum quantity */
-			wcmmq_add_cart_notice( sprintf( __( 'The maximum allowed order quantity is %s.', 'wc-min-max-quantities' ), number_format( $cart_limits['max_qty'] ) ) );
+			/* translators: %s: Maximum quantity */
+			wcmmq_add_cart_notice( sprintf( __( 'The maximum allowed order quantity is %s.', 'wc-min-max-quantities' ), wcmmq_format_qty( $cart_limits['max_qty'] ) ) );
 
 			return false;
 		}
@@ -358,8 +358,8 @@ class Cart {
 			$quantity = ! empty( $quantities[ $product_id ] ) ? $quantities[ $product_id ] : 0;
 
 			if ( $product_limits['max_qty'] > 0 && ( $quantity > $product_limits['max_qty'] ) ) {
-				/* translators: %1$s: Product name, %2$d: Maximum quantity */
-				$message = sprintf( __( 'The maximum allowed quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_title() ), number_format( $product_limits['max_qty'] ) );
+				/* translators: %1$s: Product name, %2$s: Maximum quantity */
+				$message = sprintf( __( 'The maximum allowed quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_title() ), wcmmq_format_qty( $product_limits['max_qty'] ) );
 				remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 				wcmmq_add_cart_notice( $message );
 
@@ -367,15 +367,15 @@ class Cart {
 			}
 
 			if ( $product_limits['min_qty'] > 0 && $quantity < $product_limits['min_qty'] ) {
-				/* translators: %1$s: Product name, %2$d: Minimum quantity */
-				wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_formatted_name() ), number_format( $product_limits['min_qty'] ) ) );
+				/* translators: %1$s: Product name, %2$s: Minimum quantity */
+				wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity for %1$s is %2$s.', 'wc-min-max-quantities' ), esc_html( $product->get_formatted_name() ), wcmmq_format_qty( $product_limits['min_qty'] ) ) );
 				remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
 				return;
 			}
-			if ( $product_limits['step'] > 0 && ( (float) $quantity % (float) $product_limits['step'] > 0 ) ) {
-				/* translators: %1$s: Product name, %2$d: quantity amount */
-				wcmmq_add_cart_notice( sprintf( __( '%1$s must be bought in groups of %2$s. Please increase or decrease the quantity to continue.', 'wc-min-max-quantities' ), $product->get_formatted_name(), $product_limits['step'], $product_limits['step'] - ( $quantity % $product_limits['step'] ) ) );
+			if ( ! wcmmq_is_valid_step( $quantity, $product_limits['step'] ) ) {
+				/* translators: %1$s: Product name, %2$s: quantity amount */
+				wcmmq_add_cart_notice( sprintf( __( '%1$s must be bought in groups of %2$s. Please increase or decrease the quantity to continue.', 'wc-min-max-quantities' ), $product->get_formatted_name(), wcmmq_format_qty( $product_limits['step'] ) ) );
 				remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
 				return;
@@ -386,25 +386,25 @@ class Cart {
 		$order_total    = array_sum( array_values( $line_amount ) );
 		$cart_limits    = wcmmq_get_cart_limits();
 
-		if ( (int) $cart_limits['min_qty'] > 0 && $order_quantity < (int) $cart_limits['min_qty'] ) {
-			/* translators: %d: Minimum amount of items in the cart */
-			wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity in the cart is %s. Please consider increasing the quantity in your cart.', 'wc-min-max-quantities' ), (int) $cart_limits['min_qty'] ) );
+		if ( $cart_limits['min_qty'] > 0 && $order_quantity < $cart_limits['min_qty'] ) {
+			/* translators: %s: Minimum amount of items in the cart */
+			wcmmq_add_cart_notice( sprintf( __( 'The minimum required quantity in the cart is %s. Please consider increasing the quantity in your cart.', 'wc-min-max-quantities' ), wcmmq_format_qty( $cart_limits['min_qty'] ) ) );
 			remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
 			return;
 
 		}
 
-		if ( (int) $cart_limits['max_qty'] > 0 && $order_quantity > (int) $cart_limits['max_qty'] ) {
-			/* translators: %d: Maximum amount of items in the cart */
-			wcmmq_add_cart_notice( sprintf( __( 'The maximum allowed order quantity is %s. Please reduce the quantity in your cart.', 'wc-min-max-quantities' ), (int) $cart_limits['max_qty'] ) );
+		if ( $cart_limits['max_qty'] > 0 && $order_quantity > $cart_limits['max_qty'] ) {
+			/* translators: %s: Maximum amount of items in the cart */
+			wcmmq_add_cart_notice( sprintf( __( 'The maximum allowed order quantity is %s. Please reduce the quantity in your cart.', 'wc-min-max-quantities' ), wcmmq_format_qty( $cart_limits['max_qty'] ) ) );
 			remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
 			return;
 		}
 
-		if ( (int) $cart_limits['min_total'] > 0 && $order_total < (int) $cart_limits['min_total'] ) {
-			/* translators: %d: Minimum amount of items in the cart */
+		if ( $cart_limits['min_total'] > 0 && $order_total < $cart_limits['min_total'] ) {
+			/* translators: %s: Minimum amount of items in the cart */
 			wcmmq_add_cart_notice( sprintf( __( 'The minimum allowed order total value is %s. Please consider increasing the quantity in your cart.', 'wc-min-max-quantities' ), wc_price( $cart_limits['min_total'] ) ) );
 			remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
@@ -412,8 +412,8 @@ class Cart {
 
 		}
 
-		if ( (int) $cart_limits['max_total'] > 0 && $order_total > (int) $cart_limits['max_total'] ) {
-			/* translators: %d: Maximum amount of items in the cart */
+		if ( $cart_limits['max_total'] > 0 && $order_total > $cart_limits['max_total'] ) {
+			/* translators: %s: Maximum amount of items in the cart */
 			wcmmq_add_cart_notice( sprintf( __( 'The maximum allowed order total value is %s. Please reduce the quantity in your cart.', 'wc-min-max-quantities' ), wc_price( $cart_limits['max_total'] ) ) );
 			remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
@@ -433,7 +433,7 @@ class Cart {
 		if ( 'add_to_cart' !== $add_to_cart ) {
 			return $product_id;
 		}
-		$quantity = isset( $_POST['quantity'] ) ? absint( $_POST['quantity'] ) : 1;
+		$quantity = isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : 1; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( empty( $quantity ) ) {
 			return $quantity;
 		}
@@ -470,9 +470,9 @@ class Cart {
 				return $product_id;
 			}
 
-			$remainder = $quantity % $product_limits['step'];
+			$remainder = wcmmq_is_integer_qty() ? ( absint( $quantity ) % absint( $product_limits['step'] ) ) : fmod( (float) $quantity, (float) $product_limits['step'] );
 
-			if ( 0 === $remainder ) {
+			if ( abs( $remainder ) < 0.000001 ) {
 				$_REQUEST['quantity'] = $product_limits['step'];
 			} else {
 				$_REQUEST['quantity'] = $product_limits['step'] - $remainder;
@@ -542,7 +542,7 @@ class Cart {
 		$product_limits = wcmmq_get_product_limits( $product->get_id(), $variation->get_id() );
 
 		if ( ! empty( $product_limits['min_qty'] ) ) {
-			if ( $product->managing_stock() && $product->backorders_allowed() && absint( $product_limits['min_qty'] ) > $product->get_stock_quantity() ) {
+			if ( $product->managing_stock() && $product->backorders_allowed() && $product_limits['min_qty'] > $product->get_stock_quantity() ) {
 				$data['min_qty'] = $product->get_stock_quantity();
 
 			} else {
@@ -555,7 +555,7 @@ class Cart {
 			if ( $product->managing_stock() && $product->backorders_allowed() ) {
 				$data['max_qty'] = $product_limits['max_qty'];
 
-			} elseif ( $product->managing_stock() && absint( $product_limits['max_qty'] ) > $product->get_stock_quantity() ) {
+			} elseif ( $product->managing_stock() && $product_limits['max_qty'] > $product->get_stock_quantity() ) {
 				$data['max_qty'] = $product->get_stock_quantity();
 
 			} else {
@@ -564,13 +564,13 @@ class Cart {
 		}
 
 		if ( ! empty( $product_limits['step'] ) ) {
-			$data['step'] = 1;
-			// If both minimum and maximum quantity are set, make sure both are equally divisible by quantity step of quantity.
+			$data['step'] = wcmmq_is_integer_qty() ? 1 : 'any';
+			// Only expose the configured step when the limits line up cleanly against it.
 			if ( $product_limits['max_qty'] && $product_limits['min_qty'] ) {
-				if ( absint( $product_limits['max_qty'] ) % absint( $product_limits['min_qty'] ) === 0 && absint( $product_limits['max_qty'] ) % absint( $product_limits['step'] ) === 0 ) {
+				if ( wcmmq_is_valid_step( $product_limits['max_qty'], $product_limits['min_qty'] ) && wcmmq_is_valid_step( $product_limits['max_qty'], $product_limits['step'] ) ) {
 					$data['step'] = $product_limits['step'];
 				}
-			} elseif ( ! $product_limits['max_qty'] || absint( $product_limits['max_qty'] ) % absint( $product_limits['step'] ) === 0 ) {
+			} elseif ( ! $product_limits['max_qty'] || wcmmq_is_valid_step( $product_limits['max_qty'], $product_limits['step'] ) ) {
 				$data['step'] = $product_limits['step'];
 			}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -36,6 +36,11 @@ final class Plugin extends B8\Plugin\App {
 		// Redis/Memcached/etc. would leak one user's limits to another.
 		wp_cache_add_non_persistent_groups( array( 'wc-min-max-quantities' ) );
 
+		if ( 'yes' === get_option( 'wcmmq_decimal_quantities', 'no' ) ) {
+			remove_filter( 'woocommerce_stock_amount', 'intval' );
+			add_filter( 'woocommerce_stock_amount', 'floatval' );
+		}
+
 		register_activation_hook( $this->file, array( Installer::class, 'install' ) );
 		add_filter( 'plugin_action_links_' . $this->basename(), array( $this, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -15,6 +15,61 @@ function wc_min_max_quantities() { // phpcs:ignore WordPress.NamingConventions.V
 }
 
 /**
+ * Whether WooCommerce is currently treating stock quantities as integers.
+ *
+ * Wraps wc_is_stock_amount_integer() (WC 10.1+) with a safe fallback to true for
+ * older WooCommerce versions that don't expose the helper.
+ *
+ * @since 2.3.0
+ * @return bool
+ */
+function wcmmq_is_integer_qty() {
+	return ! function_exists( 'wc_is_stock_amount_integer' ) || wc_is_stock_amount_integer();
+}
+
+/**
+ * Format a quantity for display in user-facing messages.
+ *
+ * Uses localized integer formatting when WooCommerce is in integer mode, otherwise
+ * preserves decimal precision and trims trailing zeros.
+ *
+ * @since 2.3.0
+ * @param int|float $qty The quantity to format.
+ * @return string
+ */
+function wcmmq_format_qty( $qty ) {
+	if ( wcmmq_is_integer_qty() ) {
+		return number_format_i18n( (int) $qty );
+	}
+
+	return wc_trim_zeros( (string) (float) $qty );
+}
+
+/**
+ * Check whether a quantity is a valid multiple of a given step.
+ *
+ * Uses integer modulo when WooCommerce is in integer mode, and `fmod` with a
+ * floating-point epsilon tolerance otherwise. Returns true when the step is
+ * zero or negative so callers can skip the check for products without a step.
+ *
+ * @since 2.3.0
+ * @param int|float $qty  The quantity to check.
+ * @param int|float $step The step value.
+ * @return bool
+ */
+function wcmmq_is_valid_step( $qty, $step ) {
+	if ( $step <= 0 ) {
+		return true;
+	}
+
+	if ( wcmmq_is_integer_qty() ) {
+		return absint( $qty ) % absint( $step ) === 0;
+	}
+
+	return abs( fmod( (float) $qty, (float) $step ) ) < 0.000001;
+}
+
+/**
  * Check if the product is excluded from min/max quantity.
  *
  * @param int $product_id Product ID.
@@ -48,16 +103,16 @@ function wcmmq_get_product_limits( $product_id, $variation_id = 0 ) {
 
 		if ( $override ) {
 			$limits = array(
-				'step'    => (int) get_post_meta( $product->get_id(), '_wcmmq_step', true ),
-				'min_qty' => (int) get_post_meta( $product->get_id(), '_wcmmq_min_qty', true ),
-				'max_qty' => (int) get_post_meta( $product->get_id(), '_wcmmq_max_qty', true ),
+				'step'    => (float) get_post_meta( $product->get_id(), '_wcmmq_step', true ),
+				'min_qty' => (float) get_post_meta( $product->get_id(), '_wcmmq_min_qty', true ),
+				'max_qty' => (float) get_post_meta( $product->get_id(), '_wcmmq_max_qty', true ),
 				'rule'    => 'product',
 			);
 		} else {
 			$limits = array(
-				'step'    => (int) get_option( 'wcmmq_step', 1 ),
-				'min_qty' => (int) get_option( 'wcmmq_min_qty', 1 ),
-				'max_qty' => (int) get_option( 'wcmmq_max_qty', 0 ),
+				'step'    => (float) get_option( 'wcmmq_step', 1 ),
+				'min_qty' => (float) get_option( 'wcmmq_min_qty', 1 ),
+				'max_qty' => (float) get_option( 'wcmmq_max_qty', 0 ),
 				'rule'    => 'global',
 			);
 		}
@@ -79,10 +134,10 @@ function wcmmq_get_cart_limits() {
 	$limits = apply_filters(
 		'wc_min_max_quantities_cart_limits',
 		array(
-			'min_qty'   => (int) get_option( 'wcmmq_min_cart_qty' ),
-			'max_qty'   => (int) get_option( 'wcmmq_max_cart_qty' ),
-			'min_total' => (int) get_option( 'wcmmq_min_cart_total' ),
-			'max_total' => (int) get_option( 'wcmmq_max_cart_total' ),
+			'min_qty'   => (float) get_option( 'wcmmq_min_cart_qty' ),
+			'max_qty'   => (float) get_option( 'wcmmq_max_cart_qty' ),
+			'min_total' => (float) get_option( 'wcmmq_min_cart_total' ),
+			'max_total' => (float) get_option( 'wcmmq_max_cart_total' ),
 		)
 	);
 


### PR DESCRIPTION
## Summary

Supersedes #261 (closed). Adds optional decimal quantity support to the plugin using WooCommerce's official `woocommerce_stock_amount` filter extension point. Feature is **off by default** so existing installs are unaffected.

## How it works

When the "Allow decimal quantities" setting is enabled:

1. `Plugin::bootstrap()` removes WC's default `intval` filter on `woocommerce_stock_amount` and registers `floatval` instead. WC then funnels every quantity (add-to-cart, cart updates, checkout, order items, emails, REST) through floatval — no `$_POST` hijacking, no static state, no reentrancy bugs.
2. All comparison / math / display sites in `Cart.php` branch on `wc_is_stock_amount_integer()` (WC 10.1+, with a `function_exists` fallback that assumes integer mode on older WC).
3. Helpers in `functions.php` centralize the branching: `wcmmq_is_integer_qty()`, `wcmmq_format_qty()`, `wcmmq_is_valid_step()`.
4. Admin quantity inputs get `step="any"` so decimals can be entered when the feature is on.

## Why not "just widen casts to float"

Two traps the previous PR (#261) fell into:

- **WC's `intval` filter wins by default.** `add_filter('woocommerce_stock_amount', 'floatval')` alone runs *after* WC's `intval`, which has already truncated the decimal. Data loss. Must `remove_filter` first.
- **Integer math hides in many places.** `absint()`, `%` (PHP forces int operands), and `number_format()` without precision all silently strip or round decimals. With `step=0.5` and `max_qty` set, `absint(0.5)` is `0`, and `$max % 0` **fatal-errors on PHP 8+**. These needed direct replacement with `wc_is_stock_amount_integer()` branches.

## Pro plugin coordination

Pro plugin PR submitted in parallel: https://github.com/pluginever/wc-min-max-quantities-pro/pull/new/feature/decimal-quantity. **These must merge and ship together** — the free plugin widens limit storage to float, and Pro's `Cart.php` was casting back to int via the `wc_min_max_quantities_product_limits` filter. Shipping only one would break the other.

## Files changed

| File | Change |
|---|---|
| `includes/Plugin.php` | Gated `remove_filter(intval) + add_filter(floatval)` in `bootstrap()` |
| `includes/functions.php` | Added 3 helpers, widened limit casts to `(float)` |
| `includes/Cart.php` | Replaced `absint()`/`%`/`number_format()` with helper calls at 20+ sites |
| `includes/Admin/Settings.php` | New `wcmmq_decimal_quantities` checkbox + warning copy + `step="any"` on qty fields |
| `includes/Admin/MetaBoxes.php` | `step="any"` on product step field |

## Test plan

### Setting OFF (default) — must behave identically to v2.2.9
- [ ] Fresh install, default settings → integer quantities enforced as before
- [ ] Integer min/max/step on a product → existing validation behavior
- [ ] Cart/checkout flows unchanged
- [ ] `wc_is_stock_amount_integer()` returns `true`

### Setting ON
- [ ] Enable setting → confirm WC input `inputmode` becomes `decimal` (WC handles this automatically)
- [ ] Set product min=0.5, max=5, step=0.5 → add 2.5 to cart, no fatal, validation passes
- [ ] Set step=0.5, max=3.5 → divisibility check passes (canonical `fmod` + epsilon)
- [ ] Set step=0.3 → `fmod(3.6, 0.3)` case, precision tolerance works
- [ ] Cart-level min_qty=2.5 → error message shows "2.5", not rounded
- [ ] Exceed max_qty=2.5 with 3 items → error uses `wcmmq_format_qty()`, shows "2.5"
- [ ] Variable product with decimal variation step → quantity input respects decimal step
- [ ] Store API block cart → min/max/multiple_of flow through correctly
- [ ] Order completion + order emails → quantities preserve decimals

### WC version fallback
- [ ] Force `function_exists('wc_is_stock_amount_integer')` to false (simulate WC < 10.1) → helpers fall back to integer mode, no fatals

### Pro plugin coordination
- [ ] Both branches active → role-based limits with decimal values work
- [ ] Category-level decimal limits work end-to-end
- [ ] Variation override with decimal values respected